### PR TITLE
Run multiple image processing methods

### DIFF
--- a/include/photogeo.h
+++ b/include/photogeo.h
@@ -78,8 +78,11 @@ typedef enum {
 
 /// Parameters regarding the image processing step.
 struct ptg_image_processing_parameters {
-    /// Which method to use during image processing.
-    ptg_image_processing_method image_processing_method;
+    /// The number of image processing methods to use.
+    unsigned int method_count;
+
+    /// Which methods to use during image processing.
+    ptg_image_processing_method* methods;
 };
 
 /// Method to use to quantize image.

--- a/src/image_processing/image_processing.cpp
+++ b/src/image_processing/image_processing.cpp
@@ -4,12 +4,14 @@
 #include <opencv2/imgproc.hpp>
 
 void ptgi_image_process(const ptg_image_parameters* image_parameters, const ptg_image_processing_parameters* image_processing_parameters) {
-    switch (image_processing_parameters->image_processing_method) {
-        case PTG_GAUSSIAN_BLUR:
-            cv::Mat src = cv::Mat(image_parameters->height, image_parameters->width, CV_8UC3, image_parameters->image);
-            cv::Mat dst = cv::Mat(image_parameters->height, image_parameters->width, CV_8UC3);
-            cv::filter2D(src, dst, -1, cv::getGaussianKernel(3, 0.5), cv::Point(-1, -1), 0, cv::BORDER_DEFAULT);
-            memcpy(image_parameters->image, dst.data, image_parameters->width * image_parameters->height * sizeof(ptg_color));
-            break;
+    for (unsigned int i = 0; i < image_processing_parameters->method_count; ++i) {
+        switch (image_processing_parameters->methods[i]) {
+            case PTG_GAUSSIAN_BLUR:
+                cv::Mat src = cv::Mat(image_parameters->height, image_parameters->width, CV_8UC3, image_parameters->image);
+                cv::Mat dst = cv::Mat(image_parameters->height, image_parameters->width, CV_8UC3);
+                cv::filter2D(src, dst, -1, cv::getGaussianKernel(3, 0.5), cv::Point(-1, -1), 0, cv::BORDER_DEFAULT);
+                memcpy(image_parameters->image, dst.data, image_parameters->width * image_parameters->height * sizeof(ptg_color));
+                break;
+        }
     }
 }

--- a/tools/photogeocmd/main.cpp
+++ b/tools/photogeocmd/main.cpp
@@ -113,8 +113,12 @@ int main(int argc, const char* argv[]) {
     image_parameters.color_layer_colors = foreground_colors.data();
 
     // Image processing parameters.
+    std::vector<ptg_image_processing_method> methods;
+    methods.push_back(PTG_GAUSSIAN_BLUR);
+
     ptg_image_processing_parameters image_processing_parameters;
-    image_processing_parameters.image_processing_method = PTG_GAUSSIAN_BLUR;
+    image_processing_parameters.method_count = methods.size();
+    image_processing_parameters.methods = methods.data();
 
     // Quantization parameters.
     ptg_quantization_parameters quantization_parameters;


### PR DESCRIPTION
Take in image processing methods to use as an array rather than a single enum. This allows us to run many (or no) image processing methods in a specified order.