### PR TITLE
Fix rasterize readme

### DIFF
--- a/tools/rasterize/README.md
+++ b/tools/rasterize/README.md
@@ -1,6 +1,6 @@
 # Rasterize
 
-Tool to rasterize a vector contour image and apply filters on it to make it look like a photo of a drawing.
+Tool to rasterize a vector contour image.
 
 ## Options
 


### PR DESCRIPTION
The rasterize tool is no longer supposed to apply filters to the rasterized image. That funcionality has been moved to the perturb tool.