### PR TITLE
Optimize preprocessing

### DIFF
--- a/src/image_processing/image_processing.cpp
+++ b/src/image_processing/image_processing.cpp
@@ -9,16 +9,14 @@ void ptgi_image_process(const ptg_image_parameters* image_parameters, const ptg_
     for (unsigned int i = 0; i < image_processing_parameters->method_count; ++i) {
         switch (image_processing_parameters->methods[i]) {
             case PTG_GAUSSIAN_BLUR:        
-                cv::filter2D(src, dst, -1, cv::getGaussianKernel(3, 0.5), cv::Point(-1, -1), 0, cv::BORDER_DEFAULT);
-                memcpy(image_parameters->image, dst.data, image_parameters->width * image_parameters->height * sizeof(ptg_color));
+                cv::filter2D(src, src, -1, cv::getGaussianKernel(3, 0.5), cv::Point(-1, -1), 0, cv::BORDER_DEFAULT);
                 break;
             case PTG_BILATERAL_FILTER:
                 cv::bilateralFilter(src, dst, -1, 50, 5, cv::BORDER_DEFAULT);
                 memcpy(image_parameters->image, dst.data, image_parameters->width * image_parameters->height * sizeof(ptg_color));
                 break;
             case PTG_MEDIAN_FILTER:
-                cv::medianBlur(src, dst, 3);
-                memcpy(image_parameters->image, dst.data, image_parameters->width * image_parameters->height * sizeof(ptg_color));
+                cv::medianBlur(src, src, 3);
                 break;
             case PTG_KUWAHARA_FILTER:
                 kuwahara_filter(src, dst, 2);


### PR DESCRIPTION
Avoid unnecessary copying by utilizing OpenCV's methods supporting in-place operation.

Fixes #73 